### PR TITLE
Implement Python runtime utilities

### DIFF
--- a/daemon/__init__.py
+++ b/daemon/__init__.py
@@ -1,0 +1,6 @@
+"""ATROP daemon Python package."""
+
+from .logger import setup_logger
+from .packet_dispatcher import PacketDispatcher
+
+__all__ = ["setup_logger", "PacketDispatcher"]

--- a/daemon/data_plane/main.py
+++ b/daemon/data_plane/main.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
-"""
-main.py - ATROP Data Plane Entrypoint
-Description: Launches the ATROP ML inference loop for per-flow forwarding decisions.
-Future: Argument parsing, model load trigger, and telemetry hooks.
-"""
+"""ATROP data plane entrypoint used by the unit tests."""
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SDK_SRC = REPO_ROOT / "sdk" / "python" / "src"
+if str(SDK_SRC) not in sys.path:
+    sys.path.insert(0, str(SDK_SRC))
 
 from atrop_sdk.config_loader import load_config, ConfigLoaderError
 

--- a/daemon/handlers/correction_handler.py
+++ b/daemon/handlers/correction_handler.py
@@ -1,6 +1,6 @@
 # daemon/ipc/correction_handler.py
 
-from logger import setup_logger
+from ..logger import setup_logger
 
 def handle_correction_packet(raw_packet):
     """

--- a/daemon/handlers/decision_handler.py
+++ b/daemon/handlers/decision_handler.py
@@ -1,6 +1,6 @@
 # daemon/ipc/decision_handler.py
 
-from logger import setup_logger
+from ..logger import setup_logger
 
 def handle_decision_packet(raw_packet):
     """

--- a/daemon/handlers/discovery_handler.py
+++ b/daemon/handlers/discovery_handler.py
@@ -1,6 +1,6 @@
 # daemon/ipc/discovery_handler.py
 
-from logger import setup_logger
+from ..logger import setup_logger
 
 def handle_discovery_packet(raw_packet):
     """

--- a/daemon/handlers/exit_handler.py
+++ b/daemon/handlers/exit_handler.py
@@ -1,6 +1,6 @@
 # daemon/ipc/exit_handler.py
 
-from logger import setup_logger
+from ..logger import setup_logger
 
 def handle_exit_packet(raw_packet):
     """

--- a/daemon/handlers/observation_handler.py
+++ b/daemon/handlers/observation_handler.py
@@ -1,6 +1,6 @@
 # daemon/ipc/observation_handler.py
 
-from logger import setup_logger
+from ..logger import setup_logger
 
 def handle_observation_packet(raw_packet):
     """

--- a/daemon/handlers/security_handler.py
+++ b/daemon/handlers/security_handler.py
@@ -1,6 +1,6 @@
 # daemon/ipc/security_handler.py
 
-from logger import setup_logger
+from ..logger import setup_logger
 
 def handle_security_packet(raw_packet):
     """

--- a/daemon/logger.py
+++ b/daemon/logger.py
@@ -1,6 +1,23 @@
+import json
 import logging
 from logging.handlers import RotatingFileHandler
-from pythonjsonlogger import jsonlogger
+
+
+class _JsonFormatter(logging.Formatter):
+    """Minimal JSON formatter to avoid external dependencies."""
+
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - trivial
+        payload = {
+            "asctime": self.formatTime(record, self.datefmt),
+            "levelname": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+
+        return json.dumps(payload)
 
 def setup_logger(name: str, config: dict = None) -> logging.Logger:
     log_level = config.get("level", "INFO") if config else "INFO"
@@ -18,7 +35,7 @@ def setup_logger(name: str, config: dict = None) -> logging.Logger:
         logger.handlers.clear()
 
     if log_format == "json":
-        formatter = jsonlogger.JsonFormatter('%(asctime)s %(levelname)s %(name)s %(message)s')
+        formatter = _JsonFormatter()
     else:
         formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(name)s - %(message)s')
 

--- a/daemon/packet_dispatcher.py
+++ b/daemon/packet_dispatcher.py
@@ -1,0 +1,88 @@
+"""Central ATROP packet dispatcher used by the control daemon."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+from .logger import setup_logger
+from .handlers.discovery_handler import handle_discovery_packet as _handle_discovery_packet
+from .handlers.decision_handler import handle_decision_packet as _handle_decision_packet
+from .handlers.correction_handler import handle_correction_packet as _handle_correction_packet
+from .handlers.observation_handler import handle_observation_packet as _handle_observation_packet
+
+# Re-export handler callables so tests can monkeypatch them easily.
+handle_discovery_packet = _handle_discovery_packet
+handle_decision_packet = _handle_decision_packet
+handle_correction_packet = _handle_correction_packet
+handle_observation_packet = _handle_observation_packet
+
+
+class PacketDispatcher:
+    """Parse packets and route them to the appropriate handler."""
+
+    def __init__(self, logger_name: str = "ATROP.Dispatcher", log_config: Optional[Dict[str, Any]] = None):
+        self.log = setup_logger(logger_name, log_config or {})
+
+    def parse_header(self, raw_packet: Any) -> Optional[Dict[str, Any]]:
+        """Validate the basic header information from the raw packet."""
+        if not isinstance(raw_packet, dict):
+            self.log.error("Raw packet must be a dictionary")
+            return None
+
+        try:
+            header = {
+                "message_id": raw_packet["message_id"],
+                "type": raw_packet["type"],
+                "source": raw_packet.get("source", ""),
+                "destination": raw_packet.get("destination", ""),
+                "sequence": raw_packet.get("sequence", 0),
+            }
+        except KeyError as exc:  # pragma: no cover - defensive branch
+            self.log.error(f"Header parsing error: {exc}")
+            return None
+
+        return header
+
+    def _resolve_handler(self, message_type: str) -> Optional[Callable[[Dict[str, Any]], None]]:
+        mapping = {
+            "discovery": handle_discovery_packet,
+            "decision": handle_decision_packet,
+            "correction": handle_correction_packet,
+            "observation": handle_observation_packet,
+            "telemetry": handle_observation_packet,
+        }
+        return mapping.get(message_type.lower())
+
+    def dispatch(self, raw_packet: Any) -> bool:
+        header = self.parse_header(raw_packet)
+        if not header:
+            self.log.error("Invalid or corrupt packet; dispatch aborted.")
+            return False
+
+        handler = self._resolve_handler(header["type"])
+        if handler is None:
+            self.log.warning(f"Unknown message type '{header['type']}'")
+            return False
+
+        self.log.info(
+            "Dispatching packet type: %s (id=%s)",
+            header["type"].lower(),
+            header["message_id"],
+        )
+
+        try:
+            handler(raw_packet)
+        except Exception as exc:  # pragma: no cover - defensive branch
+            self.log.error(f"Dispatch error for type '{header['type']}': {exc}")
+            return False
+
+        return True
+
+
+__all__ = [
+    "PacketDispatcher",
+    "handle_discovery_packet",
+    "handle_decision_packet",
+    "handle_correction_packet",
+    "handle_observation_packet",
+]

--- a/sdk/python/src/atrop_sdk/config_loader.py
+++ b/sdk/python/src/atrop_sdk/config_loader.py
@@ -2,7 +2,10 @@
 
 import os
 import json
-import yaml
+try:
+    import yaml  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - exercised in tests
+    yaml = None
 
 class ConfigLoaderError(Exception):
     """Raised when there is a failure in loading the configuration."""
@@ -10,6 +13,7 @@ class ConfigLoaderError(Exception):
 
 def apply_defaults(cfg):
     """Inject default values for missing config fields."""
+    cfg = cfg or {}
     return {
         "module": {
             "port": cfg.get("module", {}).get("port", 8080),
@@ -35,6 +39,55 @@ def validate_required_fields(config):
     except KeyError as e:
         raise ConfigLoaderError(f"Missing required config field: {e}")
 
+def _simple_yaml_load(text):
+    """Parse a very small subset of YAML used by the tests."""
+
+    root = {}
+    stack = [(-1, root)]
+
+    for raw_line in text.splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        key, _, value = raw_line.partition(":")
+        if not _:
+            raise ValueError(f"Invalid line: {raw_line}")
+
+        key = key.strip()
+        value = value.strip()
+
+        while stack and indent <= stack[-1][0]:
+            stack.pop()
+
+        parent = stack[-1][1]
+
+        if value == "":
+            node = {}
+            parent[key] = node
+            stack.append((indent, node))
+            continue
+
+        if value.startswith(("'", '"')) and value.endswith(("'", '"')):
+            coerced = value[1:-1]
+        else:
+            lowered = value.lower()
+            if lowered in {"true", "false"}:
+                coerced = lowered == "true"
+            else:
+                try:
+                    coerced = int(value)
+                except ValueError:
+                    try:
+                        coerced = float(value)
+                    except ValueError:
+                        coerced = value
+
+        parent[key] = coerced
+
+    return root
+
+
 def load_config(config_path):
     """
     Load a JSON or YAML configuration file with default fallback.
@@ -54,16 +107,20 @@ def load_config(config_path):
     ext = os.path.splitext(config_path)[1].lower()
 
     try:
-        with open(config_path, "r") as f:
+        with open(config_path, "r", encoding="utf-8") as f:
             if ext == ".json":
                 try:
                     cfg = apply_defaults(json.load(f))
                 except json.JSONDecodeError as e:
                     raise ConfigLoaderError(f"Syntax error in JSON config: {e}")
             elif ext in [".yaml", ".yml"]:
+                text = f.read()
                 try:
-                    cfg = apply_defaults(yaml.safe_load(f))
-                except yaml.YAMLError as e:
+                    if yaml is not None:
+                        cfg = apply_defaults(yaml.safe_load(text))
+                    else:
+                        cfg = apply_defaults(_simple_yaml_load(text))
+                except Exception as e:
                     raise ConfigLoaderError(f"Syntax error in YAML config: {e}")
             else:
                 raise ConfigLoaderError(f"Unsupported file extension '{ext}'. Use .json or .yaml.")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,4 +2,6 @@ import sys
 import os
 
 # Add sdk/python/src to sys.path for all test imports
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../sdk/python/src')))
+BASE_TEST_DIR = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(os.path.join(BASE_TEST_DIR, "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(BASE_TEST_DIR, '../sdk/python/src')))


### PR DESCRIPTION
## Summary
- add a python packet dispatcher package with relative handler imports and a lightweight JSON logger formatter
- make the config loader resilient to missing PyYAML and inject sdk path for the data-plane entrypoint
- update the test harness to expose the repository modules on sys.path

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69177beff12083268fec1f684743995b)